### PR TITLE
MQueue: send and receive `ByteString`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,32 @@
+sudo: false
+language: c
+
+addons:
+  apt:
+    packages:
+      - libgmp-dev
+      - libbsd-dev
+
 matrix:
   allow_failures:
     - env: GHCVER=head
     - env: GHCVER=7.8.1
 
 env:
- - GHCVER=7.6.1
- - GHCVER=7.6.2
- - GHCVER=7.6.3
- - GHCVER=7.8.1
- - GHCVER=head
- - HPVER=2013.2.0.0
- - HPVER=2012.4.0.0
+ - ARGS=""
+ - ARGS="--resolver lts-2"
+ - ARGS="--resolver lts-3"
+ - ARGS="--resolver lts"
+ - ARGS="--resolver nightly"
 
 before_install:
- - case "$HPVER" in
-    "") touch cabal.config ;;
-
-    "2013.2.0.0")
-      export GHCVER=7.6.3 ;
-      echo "constraints:async==2.0.1.4,attoparsec==0.10.4.0,case-insensitive==1.0.0.1,cgi==3001.1.7.5,fgl==5.4.2.4,GLUT==2.4.0.0,GLURaw==1.3.0.0,haskell-src==1.0.1.5,hashable==1.1.2.5,html==1.0.1.2,HTTP==4000.2.8,HUnit==1.2.5.2,mtl==2.1.2,network==2.4.1.2,OpenGL==2.8.0.0,OpenGLRaw==1.3.0.0,parallel==3.2.0.3,parsec==3.1.3,QuickCheck==2.6,random==1.0.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.2,split==0.2.2,stm==2.4.2,syb==0.4.0,text==0.11.3.1,transformers==0.3.0.0,unordered-containers==0.2.3.0,vector==0.10.0.1,xhtml==3000.2.1,zlib==0.5.4.1" > cabal.config ;;
-
-    "2012.4.0.0")
-      export GHCVER=7.6.2 ;
-      echo "constraints:async==2.0.1.3,cgi==3001.1.7.4,fgl==5.4.2.4,GLUT==2.1.2.1,haskell-src==1.0.1.5,html==1.0.1.2,HTTP==4000.2.5,HUnit==1.2.5.1,mtl==2.1.2,network==2.3.1.0,OpenGL==2.2.3.1,parallel==3.2.0.3,parsec==3.1.3,QuickCheck==2.5.1.1,random==1.0.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.2,split==0.2.1.1,stm==2.4,syb==0.3.7,text==0.11.2.3,transformers==0.3.0.0,vector==0.10.0.1,xhtml==3000.2.1,zlib==0.5.4.0" > cabal.config ;;
-
-    *)
-      export GHCVER=unknown ;
-      echo "unknown/invalid Haskell Platform requested" ;
-      touch cabal.config;
-      exit 1 ;;
-
-   esac
-
- - sudo add-apt-repository -y ppa:hvr/ghc
- - sudo apt-get update
- - sudo apt-get install cabal-install-1.18 ghc-$GHCVER
- - export PATH=/opt/ghc/$GHCVER/bin:$PATH
-
-install:
- - cabal-1.18 update
+  - mkdir -p ~/.local/bin
+  - export PATH=$HOME/.local/bin:$PATH
+  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 script:
- - travis_retry cabal-1.18 install -j2 --enable-tests -ftesting --only-dependencies
- - cabal-1.18 install --enable-tests -ftesting
+  - stack $ARGS --no-terminal --install-ghc test --haddock
+
+cache:
+  directories:
+    - $HOME/.stack

--- a/System/Posix/Realtime/MQueue.hsc
+++ b/System/Posix/Realtime/MQueue.hsc
@@ -220,6 +220,7 @@ mqSend :: Fd -> String -> ByteCount -> Int -> IO ()
 mqSend (Fd mqd) msg len prio = do
   withCString msg $ \ p_msg -> do
     throwErrnoPathIfMinus1 "mqSend" msg (c_mq_send mqd p_msg (fromIntegral len) (fromIntegral prio))
+    throwErrnoIfMinus1 "mqSend" (c_mq_send mqd p_msg (fromIntegral len) (fromIntegral prio))
     return ()
 
 foreign import ccall unsafe "mqueue.h mq_send"

--- a/posix-realtime.cabal
+++ b/posix-realtime.cabal
@@ -23,7 +23,7 @@ library
                   System.Posix.Realtime.RTDataTypes
                   System.Posix.Realtime.RTTime
                   System.Posix.Realtime.Aio
-  build-depends:  base > 4.5 && < 4.11, unix
+  build-depends:  base > 4.5 && < 4.11, bytestring, unix
   extensions:	CPP, ForeignFunctionInterface
 
 source-repository head

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,10 @@
+resolver: lts-3.9
+
+packages:
+  - '.'
+
+flags: {}
+extra-package-dbs: []
+extra-deps: []
+
+system-ghc: false


### PR DESCRIPTION
I think it makes more sense to send and receive `ByteString`s rather than `String`s.

Since this is an API change I suppose a version bump might be required too.  The API for sending and receiving is still slightly awkward, but it's close to the C API, which I guess has a point.  More "natural" APIs can always be layered above.
