### PR TITLE
Updated to work with ghc 8.4.4.

### DIFF
--- a/System/Posix/Realtime/RTTime.hsc
+++ b/System/Posix/Realtime/RTTime.hsc
@@ -46,6 +46,8 @@ data ClockId = Clock_Realtime
              | Clock_Process_CPUTime_ID
              | Clock_Thread_CPUTime_ID
 
+type CClockId = Int
+
 data SetTimeFlag = Timer_Abstime
 
 
@@ -155,7 +157,7 @@ foreign import ccall safe "time.h clock_settime"
 
 
 -- | Helper function that maps a clockid to it's C representation.
-mapClockId :: ClockId -> CClockId
+mapClockId :: ClockId -> System.Posix.Realtime.RTTime.CClockId
 mapClockId clockId = case clockId of
   Clock_Realtime             -> (#const CLOCK_REALTIME)
   Clock_Monotonic            -> (#const CLOCK_MONOTONIC)

--- a/System/Posix/Realtime/RTTime.hsc
+++ b/System/Posix/Realtime/RTTime.hsc
@@ -46,8 +46,6 @@ data ClockId = Clock_Realtime
              | Clock_Process_CPUTime_ID
              | Clock_Thread_CPUTime_ID
 
-type CClockId = Int
-
 data SetTimeFlag = Timer_Abstime
 
 

--- a/System/Posix/Realtime/RTTime.hsc
+++ b/System/Posix/Realtime/RTTime.hsc
@@ -32,7 +32,7 @@ module System.Posix.Realtime.RTTime (
 #include <time.h>
 
 import System.Posix.Realtime.RTDataTypes
-import System.Posix.Types
+import System.Posix.Types hiding (CClockId)
 import System.Posix.Error
 import System.Posix.Internals
 import Foreign
@@ -157,7 +157,7 @@ foreign import ccall safe "time.h clock_settime"
 
 
 -- | Helper function that maps a clockid to it's C representation.
-mapClockId :: ClockId -> System.Posix.Realtime.RTTime.CClockId
+mapClockId :: ClockId -> CClockId
 mapClockId clockId = case clockId of
   Clock_Realtime             -> (#const CLOCK_REALTIME)
   Clock_Monotonic            -> (#const CLOCK_MONOTONIC)

--- a/posix-realtime.cabal
+++ b/posix-realtime.cabal
@@ -1,5 +1,5 @@
 name:		posix-realtime
-version:	0.0.0.4
+version:	0.0.0.5
 license:	BSD3
 license-file:	LICENSE
 category:       System
@@ -15,7 +15,7 @@ description:
 cabal-version: >= 1.6
 build-type: Simple
 extra-source-files:  README.md changelog stack.yaml AUTHORS
-tested-with: GHC==7.8.4, GHC==7.10.2, GHC==7.6.3
+tested-with: GHC==7.8.4, GHC==7.10.2, GHC==7.6.3, GHC==8.4.4
 
 library
   exposed-modules:
@@ -25,8 +25,8 @@ library
                   System.Posix.Realtime.RTDataTypes
                   System.Posix.Realtime.RTTime
                   System.Posix.Realtime.Aio
-  build-depends:  base > 4.5 && < 4.11, bytestring, unix
-  extensions:	CPP, ForeignFunctionInterface
+  build-depends:  base > 4.5 && < 5, bytestring, unix
+  extensions:	  CPP, ForeignFunctionInterface
 
 source-repository head
   type:     git

--- a/posix-realtime.cabal
+++ b/posix-realtime.cabal
@@ -25,8 +25,8 @@ library
                   System.Posix.Realtime.RTDataTypes
                   System.Posix.Realtime.RTTime
                   System.Posix.Realtime.Aio
-  build-depends:  base > 4.5 && < 5, bytestring, unix
-  extensions:	  CPP, ForeignFunctionInterface
+  build-depends:  base >= 4.5 && < 5, bytestring, unix
+  extensions:	CPP, ForeignFunctionInterface
 
 source-repository head
   type:     git


### PR DESCRIPTION
```
System/Posix/Realtime/RTTime.hsc:160:26: error:
    Ambiguous occurrence ‘CClockId’
    It could refer to either ‘System.Posix.Types.CClockId’,
                             imported from ‘System.Posix.Types’ at System/Posix/Realtime/RTTime.hsc:35:1-25
                          or ‘System.Posix.Realtime.RTTime.CClockId’,
                             defined at System/Posix/Realtime/RTTime.hsc:49:1
    |
160 | mapClockId :: ClockId -> CClockId
    |                          ^^^^^^^^
```